### PR TITLE
Inputfiled Wrapper 제거 (#47)

### DIFF
--- a/src/components/Inputfield.jsx
+++ b/src/components/Inputfield.jsx
@@ -16,34 +16,25 @@ const Inputfield = forwardRef(({
   const handleBlur = () => setIsFocused(false);
 
   return (
-    <InputWrapper>
-      <StyledInput
-        type={type} 
-        placeholder={placeholder} 
-        value={value} 
-        onChange={onChange} 
+    <StyledInput
+      type={type} 
+      placeholder={placeholder} 
+      value={value} 
+      onChange={onChange} 
 
-        onFocus={handleFocus} // input 클릭(포커스) 시 실행
-        onBlur={handleBlur} // input 벗어날 때(포커스 해제) 실행
-        onKeyDown={onKeyDown} // 키보드 이벤트 처리
-        ref={ref} // ref 전달
-        $isFocused={isFocused} // 포커스 상태 전달 styled-components에 전달
+      onFocus={handleFocus} // input 클릭(포커스) 시 실행
+      onBlur={handleBlur} // input 벗어날 때(포커스 해제) 실행
+      onKeyDown={onKeyDown} // 키보드 이벤트 처리
+      ref={ref} // ref 전달
+      $isFocused={isFocused} // 포커스 상태 전달 styled-components에 전달
 
-        $customStyle={customStyle} // 커스텀 스타일 전달
-        $placeholderStyle={placeholderStyle} // placeholder 스타일 전달
-      />
-    </InputWrapper>
+      $customStyle={customStyle} // 커스텀 스타일 전달
+      $placeholderStyle={placeholderStyle} // placeholder 스타일 전달
+    />
   );
 });
 
 export default Inputfield;
-
-const InputWrapper = styled.div`
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-`;
 
 const StyledInput = styled.input`
   width: 100%;


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->
- close #47 

## ✨ 작업 내용
<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->
- props로 style을 변경할때 InputWrapper와 StyledInput을 둘다 따로 설정해줘야 하는 문제가 있었음.
  에러메시지가 따로 구현되어있지 않기 때문에, Wrapper가 필요 없다고 판단되어 삭제 
```html
<InputWrapper>
  <StyledInput><StyledInput/>
<InputWrapper/>
```
에서 InputWrapper 삭제 (스타일은 동일하게 적용)
```html
<StyledInput>
<StyledInput/>
```

## 📸 UI 작업 시
<!-- 이미지 or 영상 첨부 or 프리뷰 링크 -->


## ✅ 체크 리스트
- [x] main 브랜치 pull 완료
- [x] Assignees 설정
- [x] Labels 설정

## ⚠️ 기타 참고사항
- 
