### PR TITLE
🐛 fix : 거래 등록 폼 연속 입력 시 validation 오류 수정 (#89)

### DIFF
--- a/src/components/Dropdown.jsx
+++ b/src/components/Dropdown.jsx
@@ -10,19 +10,29 @@ const Dropdown = ({
   value, // 외부에서 선택된 값을 제어할 수 있는 value prop
 }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [selected, setSelected] = useState(() => {
+    // defaultValue가 있으면 해당 옵션을 찾아서 초기값으로 설정
+    if (defaultValue) {
+      return options.find((option) => option.value === defaultValue) || null;
+    }
+    return null;
+  });
   const ref = useRef(null);
 
   // 내부 selected 상태는 value prop이 없을 때만 사용
-  const isControlled = value !== undefined && value !== null;
-  const selected = isControlled
-    ? options.find((opt) => opt.value === value) || null
-    : (defaultValue ? options.find(option => option.value === defaultValue) || null : null);
+  useEffect(() => {
+    if (value !== undefined) {
+      const newSelected = options.find((option) => option.value === value);
+      setSelected(newSelected || null);
+    }
+  }, [value, options]);
 
   const toggleDropdown = () => setIsOpen((prev) => !prev);
 
   const handleSelect = (option) => {
+    setSelected(option);
     setIsOpen(false);
-    if (onSelect) onSelect(option);
+    if (onSelect) onSelect(option.value);
   };
 
   // 외부 클릭 시 닫기

--- a/src/components/TransactionEdit.jsx
+++ b/src/components/TransactionEdit.jsx
@@ -181,9 +181,10 @@ const TransactionEdit = forwardRef(
                 </LabelRow>
                 <Dropdown
                   options={paymentMethodOptions}
+                  value={formData.payment_method}
                   placeholder={paymentMethodOptions[0].label}
-                  onSelect={(option) =>
-                    handleInputChange("payment_method", option.value)
+                  onSelect={(value) =>
+                    handleInputChange("payment_method", value)
                   }
                   customStyle={`
                 min-width: 100%;
@@ -204,10 +205,9 @@ const TransactionEdit = forwardRef(
               </LabelRow>
               <Dropdown
                 options={categoryOptions}
+                value={formData.category}
                 placeholder={categoryOptions[0].label}
-                onSelect={(option) =>
-                  handleInputChange("category", option.value)
-                }
+                onSelect={(value) => handleInputChange("category", value)}
                 customStyle={`
                 height: 2.53125rem;
                 font-size: 0.84375rem;
@@ -233,10 +233,9 @@ const TransactionEdit = forwardRef(
               </LabelRow>
               <Dropdown
                 options={currencyOptions}
+                value={formData.currency_code}
                 placeholder={currencyOptions[0].label}
-                onSelect={(option) =>
-                  handleInputChange("currency_code", option.value)
-                }
+                onSelect={(value) => handleInputChange("currency_code", value)}
                 customStyle={`
                 height: 2.53125rem;
                 font-size: 0.84375rem;
@@ -261,7 +260,7 @@ const TransactionEdit = forwardRef(
               color: var(--white);
             `}
             >
-              <span className="h2">등록하기</span>
+              <span style={{ color: "var(--white)" }}>등록하기</span>
             </Button>
           </RegisterButtonContainer>
         )}

--- a/src/pages/AcctSummaryPage.jsx
+++ b/src/pages/AcctSummaryPage.jsx
@@ -439,6 +439,13 @@ const PageWrapper = styled.div`
   padding-top: 5.5rem;
 `;
 
+const ContentWrapper = styled.div`
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
 const Title = styled.h1`
   color: var(--black);
   font-size: 1.75rem;
@@ -573,13 +580,6 @@ const BtnBox = styled.div`
 
 //
 // —————————————————————————— (세부 프로필) ——————————————————————————
-
-const ContentWrapper = styled.div`
-  margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-`;
 
 const FormGrid = styled.div`
   display: flex;


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->
- close #89 
<br/><br/>

## ✨ 작업 내용
<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->
> **fix : 거래 등록 폼 연속 입력 시 validation 오류**
> - 첫 번째 거래 등록 후 두 번째 거래 등록 시 "모든 필수 항목을 입력해주세요" 알림 발생
> - 카테고리 드롭다운 클릭 후 모든 값 입력해도 동일한 오류 발생
<br/>

1. **원인**
   - Dropdown : 내부 상태(`selected`)만 관리하고 부모 컴포넌트 `formData`와 동기화X
   - TransactionEdit : 폼 초기화 시 `Dropdown`의 표시값 업데이트 X
   - `onSelect` 콜백에서 이미 `value`를 전달하는데? 다시 `.value` 접근해서`undefined` 저장..
   
2. **해결**
   - Dropdown : `value` prop 추가 & 외부 값 바뀌는지 `useEffect`로 알아보기
   - TransactionEdit : `value={formData.xxx}` prop 전달 to `Dropdown`
   - onSelect 콜백 파라미터 : `option`에서 `value`로 변경하여 직접 값 사용
<br/><br/>

## 📸 UI 작업 시
<!-- 이미지 or 영상 첨부 or 프리뷰 링크 -->
<br/><br/>

## ✅ 체크 리스트
- [x] main 브랜치 pull 완료
- [x] Assignees 설정
- [x] Labels 설정
<br/><br/>

## ⚠️ 기타 참고사항
<br/><br/>
